### PR TITLE
Create helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/update-operator.yml
+++ b/.github/workflows/update-operator.yml
@@ -25,4 +25,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update operator templates from upstream"
-          file_pattern: "charts/kubero/templates/**/*.yaml"
+          file_pattern: "charts/kubero/templates/*.yaml charts/kubero/templates/**/*.yaml"

--- a/.github/workflows/update-operator.yml
+++ b/.github/workflows/update-operator.yml
@@ -1,0 +1,28 @@
+name: Update Operator Templates
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-templates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Download and split operator manifest
+        run: bin/manifest-to-templates
+
+      - name: Commit updated templates
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update operator templates from upstream"
+          file_pattern: "charts/kubero/templates/**/*.yaml"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # kubero-helm
-A Helm chart to deploy a Kubero instance (Operator and UI) 
+
+A Helm chart to deploy a [Kubero](https://github.com/kubero-dev/kubero-operator) instance (Operator and UI).
+
+## Overview
+
+This chart deploys the Kubero Operator into your Kubernetes cluster. The operator manages the full Kubero ecosystem including application workloads, CI/CD pipelines, builds, and a wide range of database and service addons. It installs the operator controller-manager, all required CRDs, RBAC resources, and a metrics service.
+
+Templates are auto-generated from the [upstream operator manifest](https://raw.githubusercontent.com/kubero-dev/kubero-operator/main/deploy/operator.yaml) using a bundled Ruby script.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.x
+- Cluster-admin access (the chart installs CRDs and ClusterRoles)
+
+## Installation
+
+Add the Helm repository and install the chart:
+
+```bash
+helm repo add kubero https://kubero-dev.github.io/kubero-helm
+helm repo update
+helm install kubero kubero/kubero
+```
+
+To install into a specific namespace:
+
+```bash
+helm install kubero kubero/kubero --namespace kubero-operator-system --create-namespace
+```
+
+## Uninstallation
+
+```bash
+helm uninstall kubero
+```
+
+> **Note:** Helm does not remove CRDs on uninstall. To fully clean up, delete them manually:
+>
+> ```bash
+> kubectl get crds -o name | grep kubero.dev | xargs kubectl delete
+> ```
+
+## Configuration
+
+This chart does not expose configurable values yet. The `values.yaml` file is currently empty. Parameterization (e.g. image overrides, resource limits, replica counts) will be added in future versions.
+
+## Development
+
+### How templates are generated
+
+The `bin/manifest-to-templates` script (Ruby) downloads the monolithic upstream operator manifest, splits it into individual YAML files, and writes them to `charts/kubero/templates/` (with CRDs going into `charts/kubero/templates/crds/`).
+
+To regenerate templates locally:
+
+```bash
+# Requires Ruby 3.3+
+bin/manifest-to-templates
+```
+
+This can also be triggered via the **Update Operator Templates** GitHub Actions workflow (`workflow_dispatch`), which runs the script and auto-commits the result.
+
+### Releasing
+
+Pushes to `main` automatically package and publish the chart using [chart-releaser-action](https://github.com/helm/chart-releaser-action).
+
+## License
+
+This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/bin/manifest-to-templates
+++ b/bin/manifest-to-templates
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "open-uri"
+require "yaml"
+require "fileutils"
+
+url = "https://raw.githubusercontent.com/kubero-dev/kubero-operator/main/deploy/operator.yaml"
+dir = File.expand_path("../charts/kubero/templates", __dir__)
+crds_dir = "#{dir}/crds"
+
+FileUtils.mkdir_p(crds_dir)
+
+Dir.glob("#{dir}/**/*.yaml").each { |f| File.delete(f) }
+
+YAML.load_stream(URI.open(url).read).each do |doc|
+  if doc
+    kind = doc["kind"].downcase
+    name = doc.dig("metadata", "name").gsub(".", "-")
+
+    if kind == "customresourcedefinition"
+      target = crds_dir
+    else
+      target = dir
+    end
+
+    File.write("#{target}/#{kind}-#{name}.yaml", YAML.dump(doc))
+  end
+end

--- a/charts/kubero/Chart.yaml
+++ b/charts/kubero/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kubero
+description: A Helm chart to deploy a Kubero instance (Operator and UI)
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmemcached-admin-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmemcached-admin-role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmemcached-admin-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmemcached-editor-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmemcached-editor-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmemcached-editor-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmemcached-viewer-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmemcached-viewer-role.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmemcached-viewer-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmongodb-admin-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmongodb-admin-role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmongodb-admin-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmongodb-editor-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmongodb-editor-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmongodb-editor-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmongodb-viewer-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmongodb-viewer-role.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmongodb-viewer-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmysql-admin-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmysql-admin-role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmysql-admin-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmysql-editor-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmysql-editor-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmysql-editor-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmysql-viewer-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonmysql-viewer-role.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonmysql-viewer-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonpostgres-admin-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonpostgres-admin-role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonpostgres-admin-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonpostgres-editor-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonpostgres-editor-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonpostgres-editor-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonpostgres-viewer-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonpostgres-viewer-role.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonpostgres-viewer-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonrabbitmq-admin-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonrabbitmq-admin-role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonrabbitmq-admin-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonrabbitmq-editor-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonrabbitmq-editor-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonrabbitmq-editor-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonrabbitmq-viewer-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonrabbitmq-viewer-role.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonrabbitmq-viewer-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonredis-admin-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonredis-admin-role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonredis-admin-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonredis-editor-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonredis-editor-role.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonredis-editor-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonredis-viewer-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-kuberoaddonredis-viewer-role.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubero-operator
+  name: kubero-operator-kuberoaddonredis-viewer-role
+rules:
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis/status
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-manager-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-manager-role.yaml
@@ -1,0 +1,896 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubero-operator-manager-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  - apps
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  - ''
+  resources:
+  - roles
+  - clusterroles
+  - clusterrolebindings
+  - rolebindings
+  - secrets
+  - deployments
+  - namespaces
+  - services
+  - ingresses
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoapps
+  - kuberoapps/status
+  - kuberoapps/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  - ''
+  resources:
+  - deployments
+  - serviceaccounts
+  verbs:
+  - "*"
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  - ''
+  resources:
+  - ingresses
+  - rolebindings
+  - services
+  - jobs
+  verbs:
+  - "*"
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - opstreelabs.in
+  resources:
+  - mongodbs
+  verbs:
+  - "*"
+- apiGroups:
+  - redis.redis.opstreelabs.in
+  resources:
+  - redis
+  - redisclusters
+  verbs:
+  - "*"
+- apiGroups:
+  - postgres-operator.crunchydata.com
+  resources:
+  - postgresclusters
+  verbs:
+  - "*"
+- apiGroups:
+  - minio.min.io
+  resources:
+  - tenants
+  verbs:
+  - "*"
+- apiGroups:
+  - charts.operatorhub.io
+  resources:
+  - cockroachdbs
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.cfargotunnel.com
+  resources:
+  - tunnels
+  - tunnelbindings
+  verbs:
+  - "*"
+- apiGroups:
+  - clickhouse.altinity.com
+  resources:
+  - clickhouseinstallations
+  verbs:
+  - "*"
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - "*"
+- apiGroups:
+  - elasticsearch.k8s.elastic.co
+  resources:
+  - elasticsearches
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoes
+  - kuberoes/status
+  - kuberoes/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  - persistentvolumeclaims/finalizers
+  - persistentvolumes/finalizers
+  verbs:
+  - "*"
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - "*"
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberopipelines
+  - kuberopipelines/status
+  - kuberopipelines/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberomysqls
+  - kuberomysqls/status
+  - kuberomysqls/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberopostgresqls
+  - kuberopostgresqls/status
+  - kuberopostgresqls/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoredis
+  - kuberoredis/status
+  - kuberoredis/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberomongodbs
+  - kuberomongodbs/status
+  - kuberomongodbs/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoelasticsearches
+  - kuberoelasticsearches/status
+  - kuberoelasticsearches/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberocouchdbs
+  - kuberocouchdbs/status
+  - kuberocouchdbs/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberokafkas
+  - kuberokafkas/status
+  - kuberokafkas/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - "*"
+- apiGroups:
+  - job
+  resources:
+  - batch
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberomails
+  - kuberomails/status
+  - kuberomails/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberorabbitmqs
+  - kuberorabbitmqs/status
+  - kuberorabbitmqs/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberomemcacheds
+  - kuberomemcacheds/status
+  - kuberomemcacheds/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoprometheuses
+  - kuberoprometheuses/status
+  - kuberoprometheuses/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - clusterrolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberobuilds
+  - kuberobuilds/status
+  - kuberobuilds/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - "*"
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmysqls
+  - kuberoaddonmysqls/status
+  - kuberoaddonmysqls/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonpostgres
+  - kuberoaddonpostgres/status
+  - kuberoaddonpostgres/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonredis
+  - kuberoaddonredis/status
+  - kuberoaddonredis/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonrabbitmqs
+  - kuberoaddonrabbitmqs/status
+  - kuberoaddonrabbitmqs/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmongodbs
+  - kuberoaddonmongodbs/status
+  - kuberoaddonmongodbs/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - application.kubero.dev
+  resources:
+  - kuberoaddonmemcacheds
+  - kuberoaddonmemcacheds/status
+  - kuberoaddonmemcacheds/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"

--- a/charts/kubero/templates/clusterrole-kubero-operator-metrics-reader.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-metrics-reader.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubero-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/charts/kubero/templates/clusterrole-kubero-operator-proxy-role.yaml
+++ b/charts/kubero/templates/clusterrole-kubero-operator-proxy-role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubero-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/charts/kubero/templates/clusterrolebinding-kubero-operator-manager-rolebinding.yaml
+++ b/charts/kubero/templates/clusterrolebinding-kubero-operator-manager-rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubero-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubero-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: kubero-operator-controller-manager
+  namespace: kubero-operator-system

--- a/charts/kubero/templates/clusterrolebinding-kubero-operator-proxy-rolebinding.yaml
+++ b/charts/kubero/templates/clusterrolebinding-kubero-operator-proxy-rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubero-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubero-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: kubero-operator-controller-manager
+  namespace: kubero-operator-system

--- a/charts/kubero/templates/configmap-kubero-operator-manager-config.yaml
+++ b/charts/kubero/templates/configmap-kubero-operator-manager-config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+
+    leaderElection:
+      leaderElect: true
+      resourceName: 811c9dc5.kubero.dev
+kind: ConfigMap
+metadata:
+  name: kubero-operator-manager-config
+  namespace: kubero-operator-system

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonmemcacheds-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonmemcacheds-application-kubero-dev.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoaddonmemcacheds.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoAddonMemcached
+    listKind: KuberoAddonMemcachedList
+    plural: kuberoaddonmemcacheds
+    singular: kuberoaddonmemcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoAddonMemcached is the Schema for the kuberoaddonmemcacheds
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoAddonMemcached
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoAddonMemcached
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonmongodbs-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonmongodbs-application-kubero-dev.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoaddonmongodbs.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoAddonMongodb
+    listKind: KuberoAddonMongodbList
+    plural: kuberoaddonmongodbs
+    singular: kuberoaddonmongodb
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoAddonMongodb is the Schema for the kuberoaddonmongodbs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoAddonMongodb
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoAddonMongodb
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonmysqls-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonmysqls-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoaddonmysqls.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoAddonMysql
+    listKind: KuberoAddonMysqlList
+    plural: kuberoaddonmysqls
+    singular: kuberoaddonmysql
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoAddonMysql is the Schema for the kuberoaddonmysqls API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoAddonMysql
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoAddonMysql
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonpostgres-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonpostgres-application-kubero-dev.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoaddonpostgres.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoAddonPostgres
+    listKind: KuberoAddonPostgresList
+    plural: kuberoaddonpostgres
+    singular: kuberoaddonpostgres
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoAddonPostgres is the Schema for the kuberoaddonpostgres
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoAddonPostgres
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoAddonPostgres
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonrabbitmqs-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonrabbitmqs-application-kubero-dev.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoaddonrabbitmqs.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoAddonRabbitmq
+    listKind: KuberoAddonRabbitmqList
+    plural: kuberoaddonrabbitmqs
+    singular: kuberoaddonrabbitmq
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoAddonRabbitmq is the Schema for the kuberoaddonrabbitmqs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoAddonRabbitmq
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoAddonRabbitmq
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonredis-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoaddonredis-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoaddonredis.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoAddonRedis
+    listKind: KuberoAddonRedisList
+    plural: kuberoaddonredis
+    singular: kuberoaddonredis
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoAddonRedis is the Schema for the kuberoaddonredis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoAddonRedis
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoAddonRedis
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoapps-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoapps-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoapps.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoApp
+    listKind: KuberoAppList
+    plural: kuberoapps
+    singular: kuberoapp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoApp is the Schema for the kuberoapps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoApp
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoApp
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberobuilds-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberobuilds-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberobuilds.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoBuild
+    listKind: KuberoBuildList
+    plural: kuberobuilds
+    singular: kuberobuild
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoBuild is the Schema for the kuberobuilds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoBuild
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoBuild
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberocouchdbs-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberocouchdbs-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberocouchdbs.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoCouchDB
+    listKind: KuberoCouchDBList
+    plural: kuberocouchdbs
+    singular: kuberocouchdb
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoCouchDB is the Schema for the kuberocouchdbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoCouchDB
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoCouchDB
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoelasticsearches-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoelasticsearches-application-kubero-dev.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoelasticsearches.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoElasticsearch
+    listKind: KuberoElasticsearchList
+    plural: kuberoelasticsearches
+    singular: kuberoelasticsearch
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoElasticsearch is the Schema for the kuberoelasticsearches
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoElasticsearch
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoElasticsearch
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoes-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoes-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoes.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: Kubero
+    listKind: KuberoList
+    plural: kuberoes
+    singular: kubero
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Kubero is the Schema for the kuberoes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Kubero
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of Kubero
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberokafkas-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberokafkas-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberokafkas.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoKafka
+    listKind: KuberoKafkaList
+    plural: kuberokafkas
+    singular: kuberokafka
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoKafka is the Schema for the kuberokafkas API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoKafka
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoKafka
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberomails-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberomails-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberomails.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoMail
+    listKind: KuberoMailList
+    plural: kuberomails
+    singular: kuberomail
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoMail is the Schema for the kuberomails API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoMail
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoMail
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberomemcacheds-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberomemcacheds-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberomemcacheds.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoMemcached
+    listKind: KuberoMemcachedList
+    plural: kuberomemcacheds
+    singular: kuberomemcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoMemcached is the Schema for the kuberomemcacheds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoMemcached
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoMemcached
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberomongodbs-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberomongodbs-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberomongodbs.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoMongoDB
+    listKind: KuberoMongoDBList
+    plural: kuberomongodbs
+    singular: kuberomongodb
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoMongoDB is the Schema for the kuberomongodbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoMongoDB
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoMongoDB
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberomysqls-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberomysqls-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberomysqls.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoMysql
+    listKind: KuberoMysqlList
+    plural: kuberomysqls
+    singular: kuberomysql
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoMysql is the Schema for the kuberomysqls API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoMysql
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoMysql
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberopipelines-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberopipelines-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberopipelines.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoPipeline
+    listKind: KuberoPipelineList
+    plural: kuberopipelines
+    singular: kuberopipeline
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoPipeline is the Schema for the kuberopipelines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoPipeline
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoPipeline
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberopostgresqls-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberopostgresqls-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberopostgresqls.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoPostgresql
+    listKind: KuberoPostgresqlList
+    plural: kuberopostgresqls
+    singular: kuberopostgresql
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoPostgresql is the Schema for the kuberopostgresqls API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoPostgresql
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoPostgresql
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoprometheuses-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoprometheuses-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoprometheuses.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoPrometheus
+    listKind: KuberoPrometheusList
+    plural: kuberoprometheuses
+    singular: kuberoprometheus
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoPrometheus is the Schema for the kuberoprometheuses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoPrometheus
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoPrometheus
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberorabbitmqs-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberorabbitmqs-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberorabbitmqs.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoRabbitMQ
+    listKind: KuberoRabbitMQList
+    plural: kuberorabbitmqs
+    singular: kuberorabbitmq
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoRabbitMQ is the Schema for the kuberorabbitmqs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoRabbitMQ
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoRabbitMQ
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/crds/customresourcedefinition-kuberoredis-application-kubero-dev.yaml
+++ b/charts/kubero/templates/crds/customresourcedefinition-kuberoredis-application-kubero-dev.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberoredis.application.kubero.dev
+spec:
+  group: application.kubero.dev
+  names:
+    kind: KuberoRedis
+    listKind: KuberoRedisList
+    plural: kuberoredis
+    singular: kuberoredis
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KuberoRedis is the Schema for the kuberoredis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KuberoRedis
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of KuberoRedis
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kubero/templates/deployment-kubero-operator-controller-manager.yaml
+++ b/charts/kubero/templates/deployment-kubero-operator-controller-manager.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: kubero-operator-controller-manager
+  namespace: kubero-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        - "--leader-election-id=kubero-operator"
+        - "--zap-log-level=info"
+        image: ghcr.io/kubero-dev/kubero-operator/kuberoapp:v0.2.2
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: "/readyz"
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kubero-operator-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/kubero/templates/namespace-kubero-operator-system.yaml
+++ b/charts/kubero/templates/namespace-kubero-operator-system.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: kubero-operator-system

--- a/charts/kubero/templates/role-kubero-operator-leader-election-role.yaml
+++ b/charts/kubero/templates/role-kubero-operator-leader-election-role.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubero-operator-leader-election-role
+  namespace: kubero-operator-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/kubero/templates/rolebinding-kubero-operator-leader-election-rolebinding.yaml
+++ b/charts/kubero/templates/rolebinding-kubero-operator-leader-election-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubero-operator-leader-election-rolebinding
+  namespace: kubero-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubero-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: kubero-operator-controller-manager
+  namespace: kubero-operator-system

--- a/charts/kubero/templates/service-kubero-operator-controller-manager-metrics-service.yaml
+++ b/charts/kubero/templates/service-kubero-operator-controller-manager-metrics-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: kubero-operator-controller-manager-metrics-service
+  namespace: kubero-operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/charts/kubero/templates/serviceaccount-kubero-operator-controller-manager.yaml
+++ b/charts/kubero/templates/serviceaccount-kubero-operator-controller-manager.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubero-operator-controller-manager
+  namespace: kubero-operator-system


### PR DESCRIPTION
In response to #1, I've created a helm chart simply using a script that downloads the [current manifest](https://raw.githubusercontent.com/kubero-dev/kubero-operator/main/deploy/operator.yaml) and splits the resources into separate files.

Therefore the chart just a direct copy of the the existing manifest.
This script is in the `./bin` directory. The script is triggerable by a workflow as well.

Currently we're using this from our fork repo. We've set up a separate branch so that we could change the url to our own, and therefore include it in our [nixhelm](https://github.com/general-intelligence-systems/nixhelm) fork.
This pull request uses the official `kubero-dev/kubero-helm` url.

Also using the "chart releaser action" documented on the helm website to deploy the chart. See details of that here:
https://helm.sh/docs/howto/chart_releaser_action/